### PR TITLE
Add advanced transcription strategies doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-OliTunes - Audio to Sheet Music Converter
+# OliTunes - Audio to Sheet Music Converter
 
-This project aims to build an application that converts audio files into visible sheet music and tablature. The app will analyze various audio formats and provide users with a beautiful interface to interact with their music.
+OliTunes is an application that converts audio files into visible sheet music and tablature. It analyzes common formats (e.g. MP3, MP4) and provides an interface for exploring the results.
 
 ## Features
-- Upload audio files (.mp3, .mp4, etc.)
-- Analyze audio for chords, notes, lyrics, and instruments
+- Upload audio files
+- Analyze chords, notes, lyrics and instruments
 - Generate sheet music and tablature
 - Real-time music visualization
 - Playback controls
 - Saveable tablature files
 
-[text](https://github.com/alex-snezhko/GuitarTabber/tree/master#)
+For more information on the transcription model and possible improvements, see [docs/Transcription_Enhancement_Strategies.md](docs/Transcription_Enhancement_Strategies.md).

--- a/docs/Transcription_Enhancement_Strategies.md
+++ b/docs/Transcription_Enhancement_Strategies.md
@@ -1,0 +1,34 @@
+# Advanced Audio-to-Tab Transcription Strategies
+
+This document summarizes current best practices for improving guitar transcription models. It draws on recent research in pitch detection, sequence modeling, data augmentation, and music theory integration.
+
+## 1. Pitch Detection and Polyphonic Transcription
+- **Monophonic Tracking**: Pretrained CNN models such as CREPE achieve strong accuracy for single notes. They can serve as a reliable foundation for identifying pitches.
+- **Polyphonic Approaches**: Onsets-and-Frames style models predict note onsets and sustained frames jointly, improving precision on chords and overlapping notes. Recent Transformer variants add multiple prediction heads for onsets, offsets, and activations.
+- **Open-Source Tools**: Projects like Spotify's Basic Pitch or Google's MT3 demonstrate lightweight yet effective ways to convert audio to MIDI. Their output representations can inspire better encoding of string and fret positions.
+
+## 2. Mapping Audio to Strings and Frets
+- **Framewise Classification**: Early CNN models such as TabCNN output a six-hot encoding of frets for each string, but they ignore inter-string dependencies.
+- **Sequence Models**: Encoder–decoder architectures (RNN or Transformer) allow predictions to depend on prior context, resulting in more realistic fingering sequences.
+- **Continuous Pitch Models**: FretNet predicts a continuous pitch contour per string, later quantized to frets. This captures expressive bends and slides that discrete labels miss.
+- **Constraint-based Learning**: Loss functions that penalize improbable fret combinations help avoid unplayable tabs.
+
+## 3. Data Augmentation and Training Stability
+- **Audio Augmentations**: Random pitch shifts, EQ variations, compression, reverb, noise, and time-stretching greatly expand the training distribution and reduce overfitting.
+- **Preventing Collapse**: Curriculum training, multi-loss objectives, balanced batches, and careful learning-rate schedules stabilize optimization when the model tends to predict trivial outputs.
+- **Synthetic Data**: Rendering large tablature libraries to audio (e.g., the SynthTab approach) provides hours of paired data for pretraining before fine-tuning on real recordings.
+
+## 4. Leveraging Pretrained Audio Embeddings
+- Embeddings from models trained on massive datasets (YAMNet, Wav2Vec 2.0, CLAP) capture rich audio features. Feeding these embeddings into the Transformer can accelerate convergence and improve generalization.
+
+## 5. Injecting Music Theory and Guitar Knowledge
+- **Constraint-aware Decoding**: Enforce playable fretboard positions and in-key notes during inference.
+- **Learned Priors**: Train a language model on large tablature corpora to bias the decoder toward common fingering patterns and chord progressions.
+- **Physical Limits**: Penalize unrealistic finger stretches or duplicate pitches on different strings.
+
+## 6. Useful Datasets and Benchmarks
+- **GuitarSet**: Clean acoustic recordings with detailed annotations; a common benchmark.
+- **EGDB and GAPS**: Electric and classical guitar datasets that cover diverse tones and styles.
+- **Synthetic Corpora**: Large collections of rendered GuitarPro tabs, useful for pretraining.
+
+By combining these strategies—strong pitch detectors, context-aware decoders, heavy augmentation, pretrained embeddings, and theory-driven constraints—the transcription model can move beyond predicting only open strings and learn to generate accurate, playable tablature across a variety of guitar styles.


### PR DESCRIPTION
## Summary
- document advanced audio-to-tab model improvements
- clean up README and link to the new strategies doc

## Testing
- `pytest -q backend/test_music21.py` *(fails: ModuleNotFoundError: No module named 'music21')*

------
https://chatgpt.com/codex/tasks/task_e_68866f29d16c8329980c452d3ba0cda8